### PR TITLE
Add scripts to work with racer.tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,5 +6,7 @@ This is a collection of small scripts to extract files from the 1999 Game "Star 
 - out_splineblock.py: Extract out_splineblock.bin to Wavefront OBJ files
 - out_spriteblock.py: Extract out_spriteblock.bin to PNG files
 - out_textureblock.py: Extract out_textureblock.bin to PNG files
+- extract-racer-tab.py: Extracts strings from swep1rcr.exe which are typcially translated
+- parse-racer-tab.py: Validates racer.tab translation files
 
 Licensed under GPL version 2 or later.

--- a/extract-racer-tab.py
+++ b/extract-racer-tab.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+
+import sys
+
+strings = {}
+
+for path in sys.argv[1:]:
+  with open(path, 'rb') as in_file:
+    data = in_file.read()
+
+    identifiers = [
+      b"/LANGID",
+      b"/CREDITS_H_",
+      b"/MONDOTEXT_H_",
+      b"/SCREENTEXT_"
+    ]
+
+    for identifier in identifiers:
+      cursor = 0
+      while True:
+        start = data.find(identifier, cursor)
+        if start == -1:
+          break
+        sep = data.find(b"/", start + 1)
+        assert(sep > start)
+        end = data.find(b"\0", sep + 1)
+        assert(end > sep)
+
+        key = data[start + 1:sep]
+        value = data[sep + 1:end]
+
+        tmp = value.decode('windows-1252')
+        tmp = tmp.translate(str.maketrans({"\n": r"\n",
+                                           "\t": r"\t",
+                                           "\r": r"\r",
+                                           "\"": r"\"",
+                                           "\\": r"\\"}))
+        value = tmp.encode('windows-1252')
+
+        if key in strings:
+          print("Warning: duplicate key " + str(key), file=sys.stderr)
+        strings[key] = value
+
+        cursor = end + 1
+
+for key in strings:
+  value = strings[key].decode('windows-1252')
+  key = key.decode('ascii')
+  print(key + "\t" + value + "\r\n", end='', flush=True)

--- a/parse-racer-tab.py
+++ b/parse-racer-tab.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+
+import sys
+
+strings = {}
+
+for path in sys.argv[1:]:
+  with open(path, 'rb') as in_file:
+    data = in_file.read()
+    
+    # FIXME: Make sure first 4 bytes are not 'ENCR' or decrypt file
+
+    cursor = 0
+    while(cursor < len(data)):
+      start = cursor
+
+      # Find end of this entry
+      while(cursor < len(data)):
+        if (data[cursor] == 10 or data[cursor] == 13):
+          break
+        cursor += 1
+      end = cursor
+
+      sep = data.find(9, start)
+      key = data[start:sep]
+      value = data[sep + 1:end]
+      if key in strings:
+        print("Warning: duplicate key " + str(key), file=sys.stderr)
+      strings[key] = value
+
+      # Move to next entry
+      while(cursor < len(data)):
+        if (data[cursor] != 10 and data[cursor] != 13):
+          break
+        cursor += 1
+
+for key in strings:
+  value = strings[key].decode('windows-1252')
+  key = key.decode('ascii')
+  print("'" + key + "'  ->  '" + value + "'")


### PR DESCRIPTION
These scripts will hopefully be useful when translating the game to other languages, or generally for finding strings in the decompilation.

I'm not sure about `windows-1252` (the Western Europe codepage used by Windows). However, it seems to work fine for the french version.

I'm also not sure about the escaping of the listed symbols. It's possible that certain symbols are still missing an escape.

The parser script is pretty useless at this point. In the future it could check if a translation has all required keys from a reference file.
It might look a bit weird, but it's based on reverse engineering swep1rcr.exe .

Both tools do not support encrypted translation files yet. An issue should be created after merge.
  